### PR TITLE
typo in demo

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -41,7 +41,7 @@ function love.update(dt)
 	local data = Prof:unpack()
 end
 function love.keypressed(key)
-	if key == "esc" then 
+	if key == "escape" then 
 		ProfOn = not ProfOn
 	elseif key == ";" then 
 		drawRect = not drawRect 


### PR DESCRIPTION
"esc" isn't been used for the escape key, and wasn't in 0.9.2 either.